### PR TITLE
Purge all bytes after the trailing curly brace in event payload

### DIFF
--- a/atd_subscriber.py
+++ b/atd_subscriber.py
@@ -44,8 +44,11 @@ with DxlClient(config) as client:
             try:
                 query = event.payload.decode()
                 logger.info("Event received: " + query)
-                
-                query = query[:-3]
+
+                # The ATD json can sometimes have non-standard json characters
+                # at the end. Let's clean it up.
+                # End the json at the last curly brace: }
+                query = query[:query.rfind('}')+1]
                 query = json.loads(query)
                 
                 # Push ATD analysis data into Elasticsearch / Kibana


### PR DESCRIPTION
Previously, the last 3 bytes of the ATD payload - usually a carriage
return, line feed, and a random garbage character - were removed
from the incoming ATD event payload before being parsed as JSON.

This commit changes this code to use the approach taken by the
[ATD_PANFW project](https://github.com/PoesRaven/ATD_PANFW/blob/initial/atd_panfw.py#L129-L130) -- stripping all bytes which appear after the trailing right curly
bracket, '}', before performing JSON parsing.

This approach should allow for the stripping to still work properly
for future versions of ATD where the trailing garbage characters
should no longer be sent in the event payload. The approach should,
however, still continue to work properly for legacy versions of ATD.